### PR TITLE
Fix params merge order

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const plugins = {
         if (typeof value === 'string') {
             return get(config._functions, value)(params);
         }
-        const mergedParams = Object.assign({}, value[1], params);
+        const mergedParams = Object.assign({}, params, value[1]);
         return get(config._functions, value[0])(mergedParams);
     }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -372,7 +372,7 @@ describe('DollarConfig', () => {
                         }
                     }
                 );
-                expect(config.get('foo', { baz: 4 })).to.equal(6);
+                expect(config.get('foo', { baz: 4 })).to.equal(3);
             });
         });
 


### PR DESCRIPTION
If function is bound to some params, then they should be immutable.
Otherwise we would get weird behavior.

Let's say we have this config
```js
const config = {
    foo: { $param: 'quux' },
    bar: { $function: 'func' }
}
func = p => p.quux;

const c1 = new DollarConfig(config, { functions: { func } });
```
then `c1.get('foo', params) === c1.get('bar', params)` for any `params`.

But let's define
```js
const builded = buildConfig(config, { quux: 1 });
const c2 = new DollarConfig(builded, { functions: { func } });
```
then `c2.get('foo', params) === 1`, but `c2.get('bar', params) === params.quux`.